### PR TITLE
[FIX] 스프레드시트 검색창 enter시 오류

### DIFF
--- a/src/views/spread-search.ts
+++ b/src/views/spread-search.ts
@@ -21,6 +21,11 @@ export class SpreadSearchBar extends BaseTag {
         const searchBar = this.content as HTMLInputElement;
         const target = document.getElementById('waffle-disclaimer-bar')?.nextSibling?.firstChild!! as HTMLElement
         target.append(searchBar);
+        
+        searchBar.addEventListener("keydown", (event) => {
+            if (event.key == "Enter") event.preventDefault();
+        });
+
         searchBar.addEventListener("keyup", () => {
             const searchValue = searchBar.value;
             const testElements = document.getElementsByClassName("docs-sheet-tab-name");


### PR DESCRIPTION
### 관련된 이슈
- #32

### 작업 내역
- 스프레드시트 검색창 엔터 막는 로직 추가